### PR TITLE
feat: role assignment -> full featured RBAC validation (WIP)

### DIFF
--- a/api/v1alpha1/azurevalidator_types.go
+++ b/api/v1alpha1/azurevalidator_types.go
@@ -55,6 +55,32 @@ type Role struct {
 	RoleName *string `json:"roleName,omitempty"`
 }
 
+// Conveys that a specified security principal should have the specified permissions. Usually, the
+// security principal is a service principal and usually, the permissions are specified indirectly
+// by specifying just the name of a role.
+type RBACRule struct {
+	SecurityPrincipalID string          `json:"securityPrincipalId"`
+	Permissions         []PermissionSet `json:"subscriptionPermissionSet,omitempty"`
+}
+
+// Conveys that the security principal should be the member of a role assignment that provides the
+// specified role for the specified scope. Scope can be either subscription, resource group, or
+// resource.
+//
+// If permissions are specified, then it also conveys that the specified role should provide the
+// specified permissions. This is useful for validating a custom role when one is used instead of a
+// built-in role.
+type PermissionSet struct {
+	Role        RoleIdentifier `json:"role"`
+	Permissions []string       `json:"permissions,omitempty"`
+	Scope       string         `json:"scope,omitempty"`
+}
+
+type RoleIdentifier struct {
+	Name     *string `json:"name,omitempty"`
+	RoleName *string `json:"roleName,omitempty"`
+}
+
 // AzureValidatorStatus defines the observed state of AzureValidator
 type AzureValidatorStatus struct{}
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -4,4 +4,5 @@ const (
 	PluginCode string = "Azure"
 
 	ValidationTypeRoleAssignment string = "azure-role-assignment"
+	ValidationTypeRBAC           string = "azure-rbac"
 )

--- a/internal/utils/azure/azure.go
+++ b/internal/utils/azure/azure.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -125,4 +126,18 @@ func (c *AzureRoleAssignmentsClient) ListRoleAssignmentsForSubscription(subscrip
 		}
 	}
 	return roleAssignments, nil
+}
+
+// RoleAssignmentScopeSubscription extracts the ID of the subscription from a role assignment scope
+// string. Returns an error if the string is malformed, so that the error can be displayed in the
+// logs and the user knows they didn't configure scope somewhere in the spec correctly.
+func RoleAssignmentScopeSubscription(scope string) (string, error) {
+	re := regexp.MustCompile(`subscriptions/([a-fA-F0-9\-]+)`)
+	matches := re.FindStringSubmatch(scope)
+
+	if len(matches) < 2 {
+		return "", fmt.Errorf("no subscription GUID found in the scope string; string may be invalid")
+	}
+
+	return matches[1], nil
 }

--- a/internal/utils/azure/azure_test.go
+++ b/internal/utils/azure/azure_test.go
@@ -29,3 +29,60 @@ func Test_RoleNameFromRoleDefinitionID(t *testing.T) {
 		})
 	}
 }
+
+func TestRoleAssignmentScopeSubscription(t *testing.T) {
+	type args struct {
+		scope string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Success - resource group scope",
+			args: args{
+				scope: "/subscriptions/ee724176-6b76-4478-845c-577c730c2165/resourceGroups/resource-group-a/providers/Microsoft.Authorization/roleAssignments/bbd7cf6d-5638-42d7-8a02-adcd442a81c0",
+			},
+			want:    "ee724176-6b76-4478-845c-577c730c2165",
+			wantErr: false,
+		},
+		{
+			name: "Success - subscription scope",
+			args: args{
+				scope: "/subscriptions/d3decd23-c892-4995-be46-e5d1e25740fb/providers/Microsoft.Authorization/roleAssignments/6f6a7a0b-91f4-4d42-b968-7c6c19872c2c",
+			},
+			want:    "d3decd23-c892-4995-be46-e5d1e25740fb",
+			wantErr: false,
+		},
+		{
+			name: "Fail - unknown hierarchy in string",
+			args: args{
+				scope: "/planets/7baa89a1-6021-4526-aadc-6d6f998f5aea/plants/Microsoft.trees/evergreen/e0206297-48df-4967-b579-691f1ad4ad31",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Fail - not UUID in normal hierarchy",
+			args: args{
+				scope: "/subscriptions/sub1/resourceGroups/resource-group-a/providers/Microsoft.Authorization/roleAssignments/8230d1a2-4839-4667-8200-be1d950098d3",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RoleAssignmentScopeSubscription(tt.args.scope)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RoleAssignmentScopeSubscription() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("RoleAssignmentScopeSubscription() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/validators/rbac.go
+++ b/internal/validators/rbac.go
@@ -1,0 +1,145 @@
+package validators
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+	"github.com/go-logr/logr"
+	"github.com/spectrocloud-labs/validator-plugin-azure/api/v1alpha1"
+	"github.com/spectrocloud-labs/validator-plugin-azure/internal/constants"
+	azure_utils "github.com/spectrocloud-labs/validator-plugin-azure/internal/utils/azure"
+	vapi "github.com/spectrocloud-labs/validator/api/v1alpha1"
+	vapiconstants "github.com/spectrocloud-labs/validator/pkg/constants"
+	vapitypes "github.com/spectrocloud-labs/validator/pkg/types"
+	"github.com/spectrocloud-labs/validator/pkg/util/ptr"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// roleAssignmentAPI2 contains methods that allow getting all role assignments for a scope.
+// Note that this is the API of our Azure client facade, not a real Azure client.
+//
+// "2" refers to the fact that this is our second attempt at an interface like this in the package.
+// If we keep this approach, this will become just the interface, not 2.
+type roleAssignmentAPI2 interface {
+	ListRoleAssignmentsForScope(scope string, filter *string) ([]*armauthorization.RoleAssignment, error)
+}
+
+type RBACRuleService struct {
+	log              logr.Logger
+	api              roleAssignmentAPI2
+	getRoleLookupMap roleLookupMapProvider
+}
+
+func NewRBACRuleService(log logr.Logger, api roleAssignmentAPI2, roleLookupMapProvider roleLookupMapProvider) *RBACRuleService {
+	return &RBACRuleService{
+		log:              log,
+		api:              api,
+		getRoleLookupMap: roleLookupMapProvider,
+	}
+}
+
+// ReconcileRBACRule reconciles a role assignment rule from a validation config.
+func (s *RBACRuleService) ReconcileRBACRule(rule v1alpha1.RBACRule) (*vapitypes.ValidationResult, error) {
+
+	// Build the default ValidationResult for this role assignment rule.
+	state := vapi.ValidationSucceeded
+	latestCondition := vapi.DefaultValidationCondition()
+	latestCondition.Message = "Security principal has all required roles."
+	latestCondition.ValidationRule = fmt.Sprintf("%s-%s", vapiconstants.ValidationRulePrefix, rule.SecurityPrincipalID)
+	latestCondition.ValidationType = constants.ValidationTypeRBAC
+	validationResult := &vapitypes.ValidationResult{Condition: &latestCondition, State: &state}
+
+	failures := make([]string, 0)
+
+	for i, set := range rule.Permissions {
+		s.log.V(0).Info("Processing permission set of rule.", "set #", i+1)
+		if err := s.processPermissionSet(set, rule.SecurityPrincipalID, &failures); err != nil {
+			// Code this is returning to will take care of changing the validation result to a
+			// failed validation, using the error returned.
+			return validationResult, err
+		}
+	}
+
+	if len(failures) > 0 {
+		state = vapi.ValidationFailed
+		latestCondition.Failures = failures
+		latestCondition.Message = "Security principal missing one or more required roles."
+		latestCondition.Status = corev1.ConditionFalse
+	}
+
+	return validationResult, nil
+}
+
+// processPermissionSet processes a permission set from the rule.
+//   - set: The set to process.
+//   - principalID: The ID of the security principal to use in the filter. This comes from the rule
+//     the set is part of.
+//   - failures: The list of failures being built up while processing the entire rule. Must be
+//     non-nil.
+func (s *RBACRuleService) processPermissionSet(set v1alpha1.PermissionSet, principalID string, failures *[]string) error {
+
+	foundRoleNames := make(map[string]bool)
+
+	// Get all role assignments that apply to the specified scope where the member of the role
+	// assignment is the specified security principal. In this query, "principalId" must be a UUID,
+	// so this shouldn't have any injection vulnerabilities.
+	//
+	// Note that this also returns role assignments that assign the role because the scope is a
+	// surrounding scope (e.g. the subscription the scope is contained within), not just the scope
+	// itself.
+	filter := ptr.Ptr(url.QueryEscape(fmt.Sprintf("principalId eq '%s'", principalID)))
+	roleAssignments, err := s.api.ListRoleAssignmentsForScope(set.Scope, filter)
+	if err != nil {
+		return fmt.Errorf("failed to get role assignments: %w", err)
+	}
+
+	for _, ra := range roleAssignments {
+		if ra.Properties != nil && ra.Properties.RoleDefinitionID != nil {
+			foundRoleNames[azure_utils.RoleNameFromRoleDefinitionID(*ra.Properties.RoleDefinitionID)] = true
+		}
+	}
+
+	// First, find out whether we need to look the role up by its role name if the user provided
+	// its role name instead of its name.
+	var roleName string
+	role := set.Role
+	if role.Name != nil {
+		roleName = *role.Name
+	} else if role.RoleName != nil {
+		// To do the role name lookup, we need to get all of the role definitions that exist in the
+		// subscription that we're working with. We figure out which subscription we're working with
+		// by using the subscription from the scope of the permission set we're working on.
+		subForLookup, err := azure_utils.RoleAssignmentScopeSubscription(set.Scope)
+		if err != nil {
+			s.log.V(0).Error(err, "failed to parse subscription ID from scope string to perform role name lookup")
+			return err
+		}
+		rolelookupMap, err := s.getRoleLookupMap(subForLookup)
+		if err != nil {
+			s.log.V(0).Error(err, "failed to get role name lookup map")
+			return err
+		}
+		specifiedRoleName := *role.RoleName
+		foundName, ok := rolelookupMap[specifiedRoleName]
+		if !ok {
+			err := errNoSuchBuiltInRole
+			s.log.V(0).Error(err, "cannot validate")
+			return err
+		}
+		roleName = foundName
+	} else {
+		err := errNoRoleIdentifierSpecified
+		s.log.V(0).Error(err, "cannot validate")
+		return err
+	}
+
+	_, ok := foundRoleNames[roleName]
+	if !ok {
+		*failures = append(*failures, fmt.Sprintf("Security principal missing role %s", roleName))
+	}
+
+	// No error means the rule processor knows that if there were failures, they have been appended
+	// to the single list of failures by now.
+	return nil
+}

--- a/internal/validators/rbac_test.go
+++ b/internal/validators/rbac_test.go
@@ -1,0 +1,96 @@
+package validators
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+	"github.com/go-logr/logr"
+	"github.com/spectrocloud-labs/validator-plugin-azure/api/v1alpha1"
+	"github.com/spectrocloud-labs/validator-plugin-azure/internal/utils/test"
+	vapi "github.com/spectrocloud-labs/validator/api/v1alpha1"
+	"github.com/spectrocloud-labs/validator/pkg/types"
+	vapitypes "github.com/spectrocloud-labs/validator/pkg/types"
+	"github.com/spectrocloud-labs/validator/pkg/util/ptr"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type roleAssignmentAPI2Mock struct {
+	data []*armauthorization.RoleAssignment
+	err  error
+}
+
+func (m roleAssignmentAPI2Mock) ListRoleAssignmentsForScope(scope string, filter *string) ([]*armauthorization.RoleAssignment, error) {
+	return m.data, m.err
+}
+
+func TestRBACRuleService_ReconcileRBACRule(t *testing.T) {
+	type testCase struct {
+		apiMock        roleAssignmentAPI2Mock
+		expectedError  error
+		expectedResult types.ValidationResult
+		name           string
+		rule           v1alpha1.RBACRule
+	}
+
+	roleLookupMapProviderMock = func(subscriptionID string) (map[string]string, error) {
+		return map[string]string{
+			"Role 1": "role_1_id",
+			"Role 2": "role_2_id",
+		}, nil
+	}
+
+	cs := []testCase{
+		{
+			name: "Fail (missing role assignment)",
+			rule: v1alpha1.RBACRule{
+				SecurityPrincipalID: "sp_id",
+				Permissions: []v1alpha1.PermissionSet{
+					{
+						Role: v1alpha1.RoleIdentifier{
+							Name: ptr.Ptr("role_1_id"),
+						},
+						Scope: "/subscriptions/sub_id",
+					},
+				},
+			},
+			apiMock: roleAssignmentAPI2Mock{
+				data: []*armauthorization.RoleAssignment{},
+			},
+			expectedResult: vapitypes.ValidationResult{
+				Condition: &vapi.ValidationCondition{
+					ValidationType: "azure-rbac",
+					ValidationRule: "validation-sp_id",
+					Message:        "Security principal missing one or more required roles.",
+					Details:        []string{},
+					Failures:       []string{"Security principal missing role role_1_id"},
+					Status:         corev1.ConditionFalse,
+				},
+				State: ptr.Ptr(vapi.ValidationFailed),
+			},
+		},
+		{
+			name: "Pass (no permission sets in rule)",
+			rule: v1alpha1.RBACRule{
+				SecurityPrincipalID: "sp_id",
+			},
+			apiMock: roleAssignmentAPI2Mock{
+				data: []*armauthorization.RoleAssignment{},
+			},
+			expectedResult: vapitypes.ValidationResult{
+				Condition: &vapi.ValidationCondition{
+					ValidationType: "azure-rbac",
+					ValidationRule: "validation-sp_id",
+					Message:        "Security principal has all required roles.",
+					Details:        []string{},
+					Status:         corev1.ConditionTrue,
+				},
+				State: ptr.Ptr(vapi.ValidationSucceeded),
+			},
+		},
+	}
+	for _, c := range cs {
+		svc := NewRBACRuleService(logr.Logger{}, c.apiMock, roleLookupMapProviderMock)
+		result, err := svc.ReconcileRBACRule(c.rule)
+		test.CheckTestCase(t, result, c.expectedResult, err, c.expectedError)
+	}
+}

--- a/internal/validators/role_assignment.go
+++ b/internal/validators/role_assignment.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/go-logr/logr"
 	"github.com/spectrocloud-labs/validator-plugin-azure/api/v1alpha1"
 	"github.com/spectrocloud-labs/validator-plugin-azure/internal/constants"
@@ -19,15 +18,6 @@ import (
 
 var errNoSuchBuiltInRole = errors.New("specified role name does not correspond to a built-in role; cannot validate")
 var errNoRoleIdentifierSpecified = errors.New("neither role name nor name specified for role")
-
-// roleAssignmentAPI contains methods that allow getting all role assignments for a subscription.
-// Note that this is the API of our Azure client facade, not a real Azure client.
-type roleAssignmentAPI interface {
-	ListRoleAssignmentsForSubscription(subscriptionID string, filter *string) ([]*armauthorization.RoleAssignment, error)
-}
-
-// roleLookupMapProvider provides a lookup map of role names to names.
-type roleLookupMapProvider func(subscriptionID string) (map[string]string, error)
 
 type RoleAssignmentRuleService struct {
 	log              logr.Logger

--- a/internal/validators/validators.go
+++ b/internal/validators/validators.go
@@ -1,0 +1,13 @@
+// Package path implements validation for the rules supported by this validator plugin.
+package validators
+
+import "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+
+// roleAssignmentAPI contains methods that allow getting all role assignments for a subscription.
+// Note that this is the API of our Azure client facade, not a real Azure client.
+type roleAssignmentAPI interface {
+	ListRoleAssignmentsForSubscription(subscriptionID string, filter *string) ([]*armauthorization.RoleAssignment, error)
+}
+
+// roleLookupMapProvider provides a lookup map of role names to names.
+type roleLookupMapProvider func(subscriptionID string) (map[string]string, error)


### PR DESCRIPTION
This is the work done so far to change from role assignment validation to our new "full featured RBAC validation", where it would support all types of security principals (not just service principals), all types of scope (not just subscription), and optionally also validating the permissions that desired roles have (to help validate permissions on custom roles if they are used).

Permission validation is not here at all yet except that it's defined in the spec. Validation code only looks at roles.

This is the spec we agreed upon when planning this:

```go
type AzureValidatorSpec struct {
	// Rules for validating role assignments in Azure RBAC.
	RbacRule []RbacRule `json:"rbacRules"`
}

type RbacRule struct {
	SecurityPrincipalID      string                       `json:"securityPrincipalId"`
	SubscriptionPermissions  []SubscriptionPermissionSet  `json:"subscriptionPermissionSet,omitempty"`
	ResourceGroupPermissions []ResourceGroupPermissionSet `json:"resourceGroupPermissionSet,omitempty"`
	ResourcePermissions      []ResourcePermissionSet      `json:"resourcePermissionSet,omitempty"`
}

type RoleIdentifier struct {
    Name           *string `json:"name,omitempty"`
	RoleName       *string `json:"roleName,omitempty"`
	SubscriptionID string  `json:"subscriptionId"`
}

type SubscriptionPermissionSet struct {
	Role           RoleIdentifier `json:"role"`
	SubscriptionID string         `json:"subscriptionId"`
	Permissions    []string       `json:"permissions,omitempty"`
}

type ResourceGroupPermissionSet struct {
    Role            RoleIdentifier `json:"role"`
	ResourceGroupID string         `json:"resourceGroupId"`
	Permissions     []string       `json:"permissions,omitempty"`
}

type ResourcePermissionSet struct {
    Role            RoleIdentifier `json:"role"`
	ResourceID      string         `json:"resourceId"`
	Permissions     []string       `json:"permissions,omitempty"`
}
```

Here is the spec actually used in this draft PR, which is a simplified version that I think works better for us:

```go
// Conveys that a specified security principal should have the specified permissions. Usually, the
// security principal is a service principal and usually, the permissions are specified indirectly
// by specifying just the name of a role.
type RBACRule struct {
	SecurityPrincipalID string          `json:"securityPrincipalId"`
	Permissions         []PermissionSet `json:"subscriptionPermissionSet,omitempty"`
}

// Conveys that the security principal should be the member of a role assignment that provides the
// specified role for the specified scope. Scope can be either subscription, resource group, or
// resource.
//
// If permissions are specified, then it also conveys that the specified role should provide the
// specified permissions. This is useful for validating a custom role when one is used instead of a
// built-in role.
type PermissionSet struct {
	Role        RoleIdentifier `json:"role"`
	Permissions []string       `json:"permissions,omitempty"`
	Scope       string         `json:"scope,omitempty"`
}

type RoleIdentifier struct {
	Name     *string `json:"name,omitempty"`
	RoleName *string `json:"roleName,omitempty"`
}
```

I think this is better because I realized that in the Azure APIs, when getting a list of role assignments, you actually don't need a subscription ID to do that, you just need a scope. Therefore, scope is the most important thing. And because scopes are just strings at the end of the day, I figured it simplified both the spec and the validation code I'd need to write if I just used scope strings instead of three different structs, one for each scope. See the validation code in files changed to see what I mean, how the scope string is enough to accomplish the use case.

Also see the two test cases written so far in `rbac_test.go` to see how this would work.

If we're happy with this, I can add the rest of the validation logic needed and then tie this into the conroller. And remove the old spec.