### PR TITLE
feat: CRD validation for rule name uniqueness

### DIFF
--- a/api/v1alpha1/azurevalidator_types.go
+++ b/api/v1alpha1/azurevalidator_types.go
@@ -24,6 +24,8 @@ import (
 type AzureValidatorSpec struct {
 	// Rules for validating that the correct role assignments have been created in Azure RBAC to
 	// provide needed permissions.
+	// +kubebuilder:validation:MaxItems=5
+	// +kubebuilder:validation:XValidation:message="RBACRules must have unique names",rule="self.all(e, size(self.filter(x, x.name == e.name)) == 1)"
 	RBACRules []RBACRule `json:"rbacRules"`
 	Auth      AzureAuth  `json:"auth"`
 }
@@ -37,6 +39,9 @@ func (s AzureValidatorSpec) ResultCount() int {
 // role assignments exist that the principal has all of the permissions and no deny assignments
 // exist that deny the permissions.
 type RBACRule struct {
+	// Unique identifier for the rule in the validator. Used to ensure conditions do not overwrite
+	// each other.
+	Name string `json:"name"`
 	// The permissions that the principal must have. If the principal has permissions less than
 	// this, validation will fail. If the principal has permissions equal to or more than this
 	// (e.g., inherited permissions from higher level scope, more roles than needed) validation

--- a/config/crd/bases/validation.spectrocloud.labs_azurevalidators.yaml
+++ b/config/crd/bases/validation.spectrocloud.labs_azurevalidators.yaml
@@ -60,6 +60,10 @@ spec:
                     exist that the principal has all of the permissions and no deny
                     assignments exist that deny the permissions.
                   properties:
+                    name:
+                      description: Unique identifier for the rule in the validator.
+                        Used to ensure conditions do not overwrite each other.
+                      type: string
                     permissionSets:
                       description: The permissions that the principal must have. If
                         the principal has permissions less than this, validation will
@@ -106,10 +110,15 @@ spec:
                         or User.
                       type: string
                   required:
+                  - name
                   - permissionSets
                   - principalId
                   type: object
+                maxItems: 5
                 type: array
+                x-kubernetes-validations:
+                - message: RBACRules must have unique names
+                  rule: self.all(e, size(self.filter(x, x.name == e.name)) == 1)
             required:
             - auth
             - rbacRules

--- a/config/samples/azurevalidator-rbac-invalid1.yaml
+++ b/config/samples/azurevalidator-rbac-invalid1.yaml
@@ -7,7 +7,10 @@ spec:
     implicit: false
     secretName: azure-creds
   rbacRules:
-  - principalId: "a83574a7-53ef-4b37-b85e-99f956f0985a"
+  - name: rule-1
+    principalId: "a83574a7-53ef-4b37-b85e-99f956f0985a"
     permissionSets:
-    # Permission set is invalid because neither actions or dataActions are specified
+    # Permission set is invalid because neither actions or dataActions are specified.
+    # CR will be created but will result in failed validation results that report this problem at
+    # runtime. User would then fix and re-apply CR.
     - scope: "/subscriptions/9b16dd0b-1bea-4c9a-a291-65e6f44c4745"

--- a/config/samples/azurevalidator-rbac-invalid2.yaml
+++ b/config/samples/azurevalidator-rbac-invalid2.yaml
@@ -7,9 +7,13 @@ spec:
     implicit: false
     secretName: azure-creds
   rbacRules:
-  - principalId: "a83574a7-53ef-4b37-b85e-99f956f0985a"
+  - name: rule-1
+    principalId: "a83574a7-53ef-4b37-b85e-99f956f0985a"
     permissionSets:
-    # Permission set is invalid because there are no control Actions and no DataActions to be validated
+    # Permission set is invalid because there are no control Actions and no DataActions to be
+    # validated.
+    # CR will be created but will result in failed validation results that report this problem at
+    # runtime. User would then fix and re-apply CR.
     - scope: "/subscriptions/9b16dd0b-1bea-4c9a-a291-65e6f44c4745"
       actions: []
       dataActions: []

--- a/config/samples/azurevalidator-rbac-invalid3.yaml
+++ b/config/samples/azurevalidator-rbac-invalid3.yaml
@@ -1,0 +1,22 @@
+apiVersion: validation.spectrocloud.labs/v1alpha1
+kind: AzureValidator
+metadata:
+  name: azurevalidator-rbac-invalid3
+spec:
+  auth:
+    implicit: false
+    secretName: azure-creds
+  # rbacRules is invalid because rule names are not unique.
+  rbacRules:
+  - name: rule-1
+    principalId: "a83574a7-53ef-4b37-b85e-99f956f0985a"
+    permissionSets:
+    - scope: "/subscriptions/9b16dd0b-1bea-4c9a-a291-65e6f44c4745"
+      actions:
+      - "Microsoft.Compute/virtualMachines/read"
+  - name: rule-1
+    principalId: "a83574a7-53ef-4b37-b85e-99f956f0985b"
+    permissionSets:
+    - scope: "/subscriptions/9b16dd0b-1bea-4c9a-a291-65e6f44c4746"
+      actions:
+      - "Microsoft.Compute/virtualMachines/write"

--- a/config/samples/azurevalidator-rbac-one-permission-set-all-actions-permitted-by-one-role.yaml
+++ b/config/samples/azurevalidator-rbac-one-permission-set-all-actions-permitted-by-one-role.yaml
@@ -7,7 +7,8 @@ spec:
     implicit: false
     secretName: azure-creds
   rbacRules:
-  - principalId: "a83574a7-53ef-4b37-b85e-99f956f0985a"
+  - name: rule-1
+    principalId: "a83574a7-53ef-4b37-b85e-99f956f0985a"
     permissionSets:
     - scope: "/subscriptions/9b16dd0b-1bea-4c9a-a291-65e6f44c4745"
       # Actions provided by built-in role Contributor (b24988ac-6180-42a0-ab88-20f7382dd24c)

--- a/config/samples/azurevalidator-rbac-one-permission-set-some-actions-permitted-by-one-role.yaml
+++ b/config/samples/azurevalidator-rbac-one-permission-set-some-actions-permitted-by-one-role.yaml
@@ -8,7 +8,8 @@ spec:
     secretName: azure-creds
   rbacRules:
   # Rule is expected to result in Failed validation
-  - principalId: "9debc6b2-56be-4f03-bf0b-4762397fc327"
+  - name: rule-1
+    principalId: "9debc6b2-56be-4f03-bf0b-4762397fc327"
     permissionSets:
     - scope: "/subscriptions/9b16dd0b-1bea-4c9a-a291-65e6f44c4745"
       # Some actions provided by custom role TestCustomRole (d2dd3116-04f5-4c40-944a-c28eeeed6a2e)

--- a/internal/validators/rbac.go
+++ b/internal/validators/rbac.go
@@ -57,7 +57,7 @@ func (s *RBACRuleService) ReconcileRBACRule(rule v1alpha1.RBACRule) (*vapitypes.
 	latestCondition := vapi.DefaultValidationCondition()
 	latestCondition.Failures = []string{}
 	latestCondition.Message = "Principal has all required permissions."
-	latestCondition.ValidationRule = fmt.Sprintf("%s-%s", vapiconstants.ValidationRulePrefix, rule.PrincipalID)
+	latestCondition.ValidationRule = fmt.Sprintf("%s-%s", vapiconstants.ValidationRulePrefix, rule.Name)
 	latestCondition.ValidationType = constants.ValidationTypeRBAC
 	validationResult := &vapitypes.ValidationResult{Condition: &latestCondition, State: &state}
 


### PR DESCRIPTION
Add CRD validation with CEL for rule name uniqueness. Update samples.

While manually testing this, I found that it had no effect because despite the CRD YAML having the new validation in it, it didn't retain it after being applied to my kind cluster I use for testing. Is there anything in the changed code here that might be related to that problem?