### PR TITLE
feat: CRD validation for Actions and DataActions (inc. wildcards)

### DIFF
--- a/api/v1alpha1/azurevalidator_types.go
+++ b/api/v1alpha1/azurevalidator_types.go
@@ -47,7 +47,7 @@ type RBACRule struct {
 	// (e.g., inherited permissions from higher level scope, more roles than needed) validation
 	// will pass.
 	//+kubebuilder:validation:MinItems=1
-	//+kubebuilder:validation:MaxItems=10000
+	//+kubebuilder:validation:MaxItems=20
 	//+kubebuilder:validation:XValidation:message="Each permission set must have Actions, DataActions, or both defined",rule="self.all(item, size(item.actions) > 0 || size(item.dataActions) > 0)"
 	Permissions []PermissionSet `json:"permissionSets" yaml:"permissionSets"`
 	// The principal being validated. This can be any type of principal - Device, ForeignGroup,
@@ -65,6 +65,11 @@ type AzureAuth struct {
 	SecretName string `json:"secretName,omitempty" yaml:"secretName,omitempty"`
 }
 
+// ActionStr is a type used for Action strings and DataAction strings. Alias exists to enable
+// kubebuilder max string length validation for arrays of these.
+// +kubebuilder:validation:MaxLength=200
+type ActionStr string
+
 // Conveys that the security principal should be the member of a role assignment that provides the
 // specified role for the specified scope. Scope can be either subscription, resource group, or
 // resource.
@@ -72,11 +77,15 @@ type PermissionSet struct {
 	// If provided, the actions that the role must be able to perform. Must not contain any
 	// wildcards. If not specified, the role is assumed to already be able to perform all required
 	// actions.
-	Actions []string `json:"actions,omitempty" yaml:"actions,omitempty"`
+	//+kubebuilder:validation:MaxItems=1000
+	//+kubebuilder:validation:XValidation:message="Actions cannot have wildcards.",rule="self.all(item, !item.contains('*'))"
+	Actions []ActionStr `json:"actions,omitempty" yaml:"actions,omitempty"`
 	// If provided, the data actions that the role must be able to perform. Must not contain any
 	// wildcards. If not provided, the role is assumed to already be able to perform all required
 	// data actions.
-	DataActions []string `json:"dataActions,omitempty" yaml:"dataActions,omitempty"`
+	//+kubebuilder:validation:MaxItems=1000
+	//+kubebuilder:validation:XValidation:message="DataActions cannot have wildcards.",rule="self.all(item, !item.contains('*'))"
+	DataActions []ActionStr `json:"dataActions,omitempty" yaml:"dataActions,omitempty"`
 	// The minimum scope of the role. Role assignments found at higher level scopes will satisfy
 	// this. For example, a role assignment found with subscription scope will satisfy a permission
 	// set where the role scope specified is a resource group within that subscription.

--- a/api/v1alpha1/azurevalidator_types.go
+++ b/api/v1alpha1/azurevalidator_types.go
@@ -47,6 +47,8 @@ type RBACRule struct {
 	// (e.g., inherited permissions from higher level scope, more roles than needed) validation
 	// will pass.
 	//+kubebuilder:validation:MinItems=1
+	//+kubebuilder:validation:MaxItems=10000
+	//+kubebuilder:validation:XValidation:message="Each permission set must have Actions, DataActions, or both defined",rule="self.all(item, size(item.actions) > 0 || size(item.dataActions) > 0)"
 	Permissions []PermissionSet `json:"permissionSets" yaml:"permissionSets"`
 	// The principal being validated. This can be any type of principal - Device, ForeignGroup,
 	// Group, ServicePrincipal, or User.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -142,12 +142,12 @@ func (in *PermissionSet) DeepCopyInto(out *PermissionSet) {
 	*out = *in
 	if in.Actions != nil {
 		in, out := &in.Actions, &out.Actions
-		*out = make([]string, len(*in))
+		*out = make([]ActionStr, len(*in))
 		copy(*out, *in)
 	}
 	if in.DataActions != nil {
 		in, out := &in.DataActions, &out.DataActions
-		*out = make([]string, len(*in))
+		*out = make([]ActionStr, len(*in))
 		copy(*out, *in)
 	}
 }

--- a/chart/validator-plugin-azure/crds/validation.spectrocloud.labs_azurevalidators.yaml
+++ b/chart/validator-plugin-azure/crds/validation.spectrocloud.labs_azurevalidators.yaml
@@ -82,16 +82,32 @@ spec:
                               If not specified, the role is assumed to already be
                               able to perform all required actions.
                             items:
+                              description: ActionStr is a type used for Action strings
+                                and DataAction strings. Alias exists to enable kubebuilder
+                                max string length validation for arrays of these.
+                              maxLength: 200
                               type: string
+                            maxItems: 1000
                             type: array
+                            x-kubernetes-validations:
+                            - message: Actions cannot have wildcards.
+                              rule: self.all(item, !item.contains('*'))
                           dataActions:
                             description: If provided, the data actions that the role
                               must be able to perform. Must not contain any wildcards.
                               If not provided, the role is assumed to already be able
                               to perform all required data actions.
                             items:
+                              description: ActionStr is a type used for Action strings
+                                and DataAction strings. Alias exists to enable kubebuilder
+                                max string length validation for arrays of these.
+                              maxLength: 200
                               type: string
+                            maxItems: 1000
                             type: array
+                            x-kubernetes-validations:
+                            - message: DataActions cannot have wildcards.
+                              rule: self.all(item, !item.contains('*'))
                           scope:
                             description: The minimum scope of the role. Role assignments
                               found at higher level scopes will satisfy this. For
@@ -102,7 +118,7 @@ spec:
                         required:
                         - scope
                         type: object
-                      maxItems: 10000
+                      maxItems: 20
                       minItems: 1
                       type: array
                       x-kubernetes-validations:

--- a/chart/validator-plugin-azure/crds/validation.spectrocloud.labs_azurevalidators.yaml
+++ b/chart/validator-plugin-azure/crds/validation.spectrocloud.labs_azurevalidators.yaml
@@ -102,8 +102,14 @@ spec:
                         required:
                         - scope
                         type: object
+                      maxItems: 10000
                       minItems: 1
                       type: array
+                      x-kubernetes-validations:
+                      - message: Each permission set must have Actions, DataActions,
+                          or both defined
+                        rule: self.all(item, size(item.actions) > 0 || size(item.dataActions)
+                          > 0)
                     principalId:
                       description: The principal being validated. This can be any
                         type of principal - Device, ForeignGroup, Group, ServicePrincipal,

--- a/config/crd/bases/validation.spectrocloud.labs_azurevalidators.yaml
+++ b/config/crd/bases/validation.spectrocloud.labs_azurevalidators.yaml
@@ -82,16 +82,32 @@ spec:
                               If not specified, the role is assumed to already be
                               able to perform all required actions.
                             items:
+                              description: ActionStr is a type used for Action strings
+                                and DataAction strings. Alias exists to enable kubebuilder
+                                max string length validation for arrays of these.
+                              maxLength: 200
                               type: string
+                            maxItems: 1000
                             type: array
+                            x-kubernetes-validations:
+                            - message: Actions cannot have wildcards.
+                              rule: self.all(item, !item.contains('*'))
                           dataActions:
                             description: If provided, the data actions that the role
                               must be able to perform. Must not contain any wildcards.
                               If not provided, the role is assumed to already be able
                               to perform all required data actions.
                             items:
+                              description: ActionStr is a type used for Action strings
+                                and DataAction strings. Alias exists to enable kubebuilder
+                                max string length validation for arrays of these.
+                              maxLength: 200
                               type: string
+                            maxItems: 1000
                             type: array
+                            x-kubernetes-validations:
+                            - message: DataActions cannot have wildcards.
+                              rule: self.all(item, !item.contains('*'))
                           scope:
                             description: The minimum scope of the role. Role assignments
                               found at higher level scopes will satisfy this. For
@@ -102,7 +118,7 @@ spec:
                         required:
                         - scope
                         type: object
-                      maxItems: 10000
+                      maxItems: 20
                       minItems: 1
                       type: array
                       x-kubernetes-validations:

--- a/config/crd/bases/validation.spectrocloud.labs_azurevalidators.yaml
+++ b/config/crd/bases/validation.spectrocloud.labs_azurevalidators.yaml
@@ -102,8 +102,14 @@ spec:
                         required:
                         - scope
                         type: object
+                      maxItems: 10000
                       minItems: 1
                       type: array
+                      x-kubernetes-validations:
+                      - message: Each permission set must have Actions, DataActions,
+                          or both defined
+                        rule: self.all(item, size(item.actions) > 0 || size(item.dataActions)
+                          > 0)
                     principalId:
                       description: The principal being validated. This can be any
                         type of principal - Device, ForeignGroup, Group, ServicePrincipal,

--- a/internal/validators/rbac.go
+++ b/internal/validators/rbac.go
@@ -118,8 +118,18 @@ func (s *RBACRuleService) processPermissionSet(set v1alpha1.PermissionSet, princ
 		roleDefinitions = append(roleDefinitions, roleDefinition)
 	}
 
+	// Convert from ActionStr to string.
+	setActions := []string{}
+	for _, a := range set.Actions {
+		setActions = append(setActions, string(a))
+	}
+	setDataActions := []string{}
+	for _, da := range set.DataActions {
+		setDataActions = append(setDataActions, string(da))
+	}
+
 	// Get the results and append failure messages if needed.
-	result, err := processAllCandidateActions(set.Actions, set.DataActions, denyAssignments, roleDefinitions)
+	result, err := processAllCandidateActions(setActions, setDataActions, denyAssignments, roleDefinitions)
 	if err != nil {
 		return fmt.Errorf("failed to determine which candidate Actions and DataActions were denied and/or unpermitted: %w", err)
 	}

--- a/internal/validators/rbac.go
+++ b/internal/validators/rbac.go
@@ -81,21 +81,6 @@ func (s *RBACRuleService) ReconcileRBACRule(rule v1alpha1.RBACRule) (*vapitypes.
 // processPermissionSet processes a permission set from the rule.
 func (s *RBACRuleService) processPermissionSet(set v1alpha1.PermissionSet, principalID string, failures *[]string) error {
 
-	// We consider this spec invalid. Both are optional at the spec level because we need to allow
-	// users to validate a set of required control Actions, a set of required DataActions, or both.
-	// But, if a user provides neither, it means they don't have any validation to be done, and they
-	// shouldn't create the AzureValidator.
-	if set.Actions == nil && set.DataActions == nil {
-		return fmt.Errorf("spec invalid; must specify at least actions or dataActions in each permission set")
-	}
-
-	// Also invalid. If they've specified one or the other, but end up being empty in Go, it again
-	// means that they've only specified empty lists in the YAML, and they don't have any
-	// validation to be done, and they shouldn't create the AzureValidator.
-	if len(set.Actions) == 0 && len(set.DataActions) == 0 {
-		return fmt.Errorf("spec invalid; must have at least one required Action or one required DataAction to validate")
-	}
-
 	// Get all deny assignments and role assignments for specified scope and principal.
 	// Note that in this filter, Azure checks "principalId" to make sure it's a UUID, so we don't
 	// need to escape the principal ID user input from the spec.

--- a/internal/validators/rbac_permissions.go
+++ b/internal/validators/rbac_permissions.go
@@ -54,6 +54,9 @@ type roleInfo struct {
 // processAllCandidateActions determines, based on a set of deny assignments and roles (associated
 // with role assignments), which required actions and data actions are denied by presence of deny
 // assignment and/or unpermitted by lack of role assignment.
+//
+// It is assumed that all required actions and data actions have no wildcards because of CRD
+// validation.
 func processAllCandidateActions(candidateActions, candidateDataActions []string, denyAssignments []*armauthorization.DenyAssignment, roles []*armauthorization.RoleDefinition) (result, error) {
 	errNil := func(subject string) error {
 		return fmt.Errorf("%s nil", subject)
@@ -66,19 +69,6 @@ func processAllCandidateActions(candidateActions, candidateDataActions []string,
 	}
 	appendRoleInfo := func(vals *[]roleInfo, val roleInfo) {
 		*vals = append(*vals, val)
-	}
-
-	// Validate the candidate Actions and DataActions specified by the user for our algorithm's
-	// constraints. They must not have any wildcards.
-	for _, c := range candidateActions {
-		if numWildcards(c) > 0 {
-			return result{}, fmt.Errorf("candidate Actions must not have wildcards")
-		}
-	}
-	for _, c := range candidateDataActions {
-		if numWildcards(c) > 0 {
-			return result{}, fmt.Errorf("candidate DataActions must not have wildcards")
-		}
 	}
 
 	// Dereference all the data from Azure, while validating it for our algorithm's constraints.

--- a/internal/validators/rbac_permissions_test.go
+++ b/internal/validators/rbac_permissions_test.go
@@ -30,50 +30,6 @@ func Test_processAllCandidateActions(t *testing.T) {
 
 		// Cases that test invalid input.
 		{
-			name: "candidate Action with wildcard",
-			args: args{
-				candidateActions:     []string{"*"},
-				candidateDataActions: []string{},
-				denyAssignments:      []*armauthorization.DenyAssignment{},
-				roles:                []*armauthorization.RoleDefinition{},
-			},
-			want:    result{},
-			wantErr: true,
-		},
-		{
-			name: "candidate Action with multiple wildcards",
-			args: args{
-				candidateActions:     []string{"*/*"},
-				candidateDataActions: []string{},
-				denyAssignments:      []*armauthorization.DenyAssignment{},
-				roles:                []*armauthorization.RoleDefinition{},
-			},
-			want:    result{},
-			wantErr: true,
-		},
-		{
-			name: "candidate DataAction with wildcard",
-			args: args{
-				candidateActions:     []string{"a"},
-				candidateDataActions: []string{"*"},
-				denyAssignments:      []*armauthorization.DenyAssignment{},
-				roles:                []*armauthorization.RoleDefinition{},
-			},
-			want:    result{},
-			wantErr: true,
-		},
-		{
-			name: "candidate DataAction with multiple wildcards",
-			args: args{
-				candidateActions:     []string{"a"},
-				candidateDataActions: []string{"*/*"},
-				denyAssignments:      []*armauthorization.DenyAssignment{},
-				roles:                []*armauthorization.RoleDefinition{},
-			},
-			want:    result{},
-			wantErr: true,
-		},
-		{
 			name: "nil deny assignment",
 			args: args{
 				candidateActions:     []string{},

--- a/internal/validators/rbac_test.go
+++ b/internal/validators/rbac_test.go
@@ -75,8 +75,8 @@ func TestRBACRuleService_ReconcileRBACRule(t *testing.T) {
 				Name: "rule-1",
 				Permissions: []v1alpha1.PermissionSet{
 					{
-						Actions:     []string{"a"},
-						DataActions: []string{"b"},
+						Actions:     []v1alpha1.ActionStr{"a"},
+						DataActions: []v1alpha1.ActionStr{"b"},
 						Scope:       subscriptionScope,
 					},
 				},
@@ -132,8 +132,8 @@ func TestRBACRuleService_ReconcileRBACRule(t *testing.T) {
 				Name: "rule-1",
 				Permissions: []v1alpha1.PermissionSet{
 					{
-						Actions:     []string{"a"},
-						DataActions: []string{"b"},
+						Actions:     []v1alpha1.ActionStr{"a"},
+						DataActions: []v1alpha1.ActionStr{"b"},
 						Scope:       subscriptionScope,
 					},
 				},
@@ -206,8 +206,8 @@ func TestRBACRuleService_ReconcileRBACRule(t *testing.T) {
 				Name: "rule-1",
 				Permissions: []v1alpha1.PermissionSet{
 					{
-						Actions:     []string{"a"},
-						DataActions: []string{"b"},
+						Actions:     []v1alpha1.ActionStr{"a"},
+						DataActions: []v1alpha1.ActionStr{"b"},
 						Scope:       subscriptionScope,
 					},
 				},


### PR DESCRIPTION
Two commits:

1) Replaces our runtime checking with CRD validation for presence of one, the other, or both.
2) A bit more advanced, and a lot more expensive, but hopefully still realistic. Replaces our runtime checking for wildcard presence in either with CRD validation. This meant limiting the number of permission sets per rule to 20 and the number of characters per Action/DataAction to 200 (I saw as long as 133 when skimming [Azure's docs](https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations)).

Note that there is still runtime checking for more than one wildcard in role/deny assignments because we don't know those until runtime. Can't know them at CR apply time.

Note `type ActionStr string` which is a little trick to let you use kubebuilder annotations for max string length when you have arrays of strings without having to use CEL. It seems to be an [officially endorsed](https://github.com/kubernetes-sigs/controller-tools/issues/342) way of doing this.

Also added some integration tests to test this validation.