### PR TITLE
PLT-901: Azure plugin UX improvement (when SP used to auth lacks permissions)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,8 +29,6 @@ jobs:
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3
         with:
           file: ./cover.out
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-chart:
     name: Run Helm Chart Tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,8 @@ jobs:
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3
         with:
           file: ./cover.out
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-chart:
     name: Run Helm Chart Tests

--- a/internal/controller/azurevalidator_controller.go
+++ b/internal/controller/azurevalidator_controller.go
@@ -104,7 +104,7 @@ func (r *AzureValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		rdClient := azure_utils.NewAzureRoleDefinitionsClient(azureAPI.RoleDefinitions)
 
 		// RBAC rules
-		svc := validators.NewRBACRuleService(r.Log, daClient, raClient, rdClient)
+		svc := validators.NewRBACRuleService(daClient, raClient, rdClient)
 		for _, rule := range validator.Spec.RBACRules {
 			validationResult, err := svc.ReconcileRBACRule(rule)
 			if err != nil {

--- a/internal/utils/azure-errors/errors.go
+++ b/internal/utils/azure-errors/errors.go
@@ -54,7 +54,7 @@ func AsAugmented(err error) error {
 		return fmt.Errorf("invalid client secret provided for client ID; %s: %w", authHelpMsg, err)
 	}
 	if authFailed(err) {
-		return fmt.Errorf("plugin authenticated as service principal successfully but principal was unauthorized; ensure principal has permissions for operations Microsoft.Authorization/roleAssignments/read and Microsoft.Authorization/denyAssignments/read via role assignments and that no deny assignments forbid them: %w", err)
+		return fmt.Errorf("plugin authenticated as service principal successfully but principal was unauthorized; ensure principal has permissions for operations Microsoft.Authorization/roleAssignments/read, Microsoft.Authorization/denyAssignments/read, and Microsoft.Authorization/roleDefinitions/read via role assignments and that no deny assignments forbid them: %w", err)
 	}
 
 	return err

--- a/internal/utils/azure-errors/errors.go
+++ b/internal/utils/azure-errors/errors.go
@@ -1,0 +1,61 @@
+package azure_errors
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+const (
+	authHelpMsg = "ensure Azure plugin is authenticated correctly; see plugin README for authentication details"
+)
+
+// defaultAzureCredential returns whether the issue that caused error err to be returned by the
+// Azure SDK when it was used for an API request was that the SDK failed to use the
+// defaultAzureCredential strategy to authenticate the request.
+//   - err: An error returned by the Azure SDK during an API request.
+func defaultAzureCredential(err error) bool {
+	return strings.Contains(err.Error(), "DefaultAzureCredential: ")
+}
+
+// badClientSecret returns whether the issue that caused error err to be returned by the Azure SDK
+// when it was used for an API request was that was that the SDK failed to authenticate the request
+// because the client secret used was not a correct client secret for the client ID used.
+//   - err: An error returned by the Azure SDK during an API request.
+func badClientSecret(err error) bool {
+	return strings.Contains(err.Error(), "AADSTS7000215")
+}
+
+// authFailed returns whether the issue that caused error err to be returned by the Azure SDK when
+// it was used for an API request was that the security principal authenticated was unauthorized
+// (e.g. missing required role assignment).
+//   - err: An error returned by the Azure SDK during an API request.
+func authFailed(err error) bool {
+	var rerr *azcore.ResponseError
+	return errors.As(err, &rerr) && rerr.ErrorCode == "AuthorizationFailed"
+}
+
+// AsAugmented checks whether an error returned by the Azure SDK matched some known Azure errors. If
+// the error matches, it produces a new, augmented error by adding information we think will help
+// the user use the plugin correctly. If it didn't match, it returns the error as is.
+//
+// This is useful for how we want to do error handling in the plugin. We don't need to know which
+// errors occurred. We just want to log them. But, when we log them, we want as much helpful
+// information as possible to be logged.
+//   - err: An error returned by the Azure SDK.
+func AsAugmented(err error) error {
+	// This is the order Azure returns various errors in. We check them in that order.
+	if defaultAzureCredential(err) {
+		return fmt.Errorf("DefaultAzureCredential error; %s: %w", authHelpMsg, err)
+	}
+	if badClientSecret(err) {
+		return fmt.Errorf("invalid client secret provided for client ID; %s: %w", authHelpMsg, err)
+	}
+	if authFailed(err) {
+		return fmt.Errorf("plugin authenticated as service principal successfully but principal was unauthorized; ensure principal has permissions for operations Microsoft.Authorization/roleAssignments/read and Microsoft.Authorization/denyAssignments/read via role assignments and that no deny assignments forbid them: %w", err)
+	}
+
+	return err
+}

--- a/internal/validators/rbac.go
+++ b/internal/validators/rbac.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
-	"github.com/go-logr/logr"
 	"github.com/spectrocloud-labs/validator-plugin-azure/api/v1alpha1"
 	"github.com/spectrocloud-labs/validator-plugin-azure/internal/constants"
 	azure_errors "github.com/spectrocloud-labs/validator-plugin-azure/internal/utils/azure-errors"
@@ -35,15 +34,13 @@ type roleDefinitionAPI interface {
 }
 
 type RBACRuleService struct {
-	log   logr.Logger
 	daAPI denyAssignmentAPI
 	raAPI roleAssignmentAPI
 	rdAPI roleDefinitionAPI
 }
 
-func NewRBACRuleService(log logr.Logger, daAPI denyAssignmentAPI, raAPI roleAssignmentAPI, rdAPI roleDefinitionAPI) *RBACRuleService {
+func NewRBACRuleService(daAPI denyAssignmentAPI, raAPI roleAssignmentAPI, rdAPI roleDefinitionAPI) *RBACRuleService {
 	return &RBACRuleService{
-		log:   log,
 		daAPI: daAPI,
 		raAPI: raAPI,
 		rdAPI: rdAPI,

--- a/internal/validators/rbac.go
+++ b/internal/validators/rbac.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spectrocloud-labs/validator-plugin-azure/api/v1alpha1"
 	"github.com/spectrocloud-labs/validator-plugin-azure/internal/constants"
+	azure_errors "github.com/spectrocloud-labs/validator-plugin-azure/internal/utils/azure-errors"
 	vapi "github.com/spectrocloud-labs/validator/api/v1alpha1"
 	vapiconstants "github.com/spectrocloud-labs/validator/pkg/constants"
 	vapitypes "github.com/spectrocloud-labs/validator/pkg/types"
@@ -87,7 +88,7 @@ func (s *RBACRuleService) processPermissionSet(set v1alpha1.PermissionSet, princ
 	daFilter := ptr.Ptr(fmt.Sprintf("principalId eq '%s'", principalID))
 	denyAssignments, err := s.daAPI.GetDenyAssignmentsForScope(set.Scope, daFilter)
 	if err != nil {
-		return fmt.Errorf("failed to get deny assignments: %w", err)
+		return fmt.Errorf("failed to get deny assignments: %w", azure_errors.AsAugmented(err))
 	}
 	// Note that Azure's Go SDK for their API has a bug where it doesn't escape the filter string
 	// for the role assignments call we do here, so we manually escape it ourselves.
@@ -95,7 +96,7 @@ func (s *RBACRuleService) processPermissionSet(set v1alpha1.PermissionSet, princ
 	raFilter := ptr.Ptr(url.QueryEscape(fmt.Sprintf("principalId eq '%s'", principalID)))
 	roleAssignments, err := s.raAPI.GetRoleAssignmentsForScope(set.Scope, raFilter)
 	if err != nil {
-		return fmt.Errorf("failed to get role assignments: %w", err)
+		return fmt.Errorf("failed to get role assignments: %w", azure_errors.AsAugmented(err))
 	}
 
 	// For each role assignment found, get its role definition, because that's what we actually need
@@ -113,7 +114,7 @@ func (s *RBACRuleService) processPermissionSet(set v1alpha1.PermissionSet, princ
 		// ID", but in the role definitions API, it is called "role ID".
 		roleDefinition, err := s.rdAPI.GetByID(rdID)
 		if err != nil {
-			return fmt.Errorf("failed to get role definition using role definition ID of role assignment: %w", err)
+			return fmt.Errorf("failed to get role definition using role definition ID of role assignment: %w", azure_errors.AsAugmented(err))
 		}
 		roleDefinitions = append(roleDefinitions, roleDefinition)
 	}


### PR DESCRIPTION
Add better error handling (better messages to user via validation result).

Now, it'll look more like this in the validation result:

```
<error content up the call chain>: plugin authenticated as service principal successfully but principal was unauthorized; ensure principal has permissions for operations Microsoft.Authorization/roleAssignments/read and Microsoft.Authorization/denyAssignments/read via role assignments and that no deny assignments forbid them: GET https://management.azure.com/subscriptions/<subscription-id>/providers/Microsoft.Authorization/roleAssignments
--------------------------------------------------------------------------------
RESPONSE 403: 403 Forbidden
ERROR CODE: AuthorizationFailed
--------------------------------------------------------------------------------
{
  "error": {
    "code": "AuthorizationFailed",
    "message": "The client '<client-id>' with object id '<client-id>' does not have authorization to perform action 'Microsoft.Authorization/roleAssignments/read' over scope '/subscriptions/<subscription-id>' or the scope is invalid. If access was recently granted, please refresh your credentials."
  }
}
--------------------------------------------------------------------------------
```